### PR TITLE
#1 buttonAtomの作成

### DIFF
--- a/src/components/learnPage/atoms/button.tsx
+++ b/src/components/learnPage/atoms/button.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components'
+
+interface ButtonProps {
+  fontSize?: string
+  fontWeight?: string
+  letterSpacing?: string
+  lineHeight?: string
+  textAlign?: string
+  color?: string
+  backgroundColor?: string
+  width?: string
+  height?: string
+  minWidth?: string
+  minHeight?: string
+  display?: string
+  border?: string
+  borderRadius?: string
+  overflow?: string
+  margin?: string
+  marginTop?: string
+  marginLeft?: string
+  marginRight?: string
+  marginBottom?: string
+  padding?: string
+  paddingTop?: string
+  paddingLeft?: string
+  paddingRight?: string
+  paddingBottom?: string
+  pseudoClass?: {
+    hover?: {
+      backgroundColor?: string
+    }
+    disabled?: {
+      backgroundColor?: string
+    }
+  }
+}
+
+const Button = styled.button<ButtonProps>`
+  font-size: ${({ fontSize }) => fontSize};
+  color: ${({ color }) => color};
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  font-weight: ${({ fontWeight }) => fontWeight};
+  letter-spacing: ${({ letterSpacing }) => letterSpacing};
+  line-height: ${({ lineHeight }) => lineHeight};
+  text-align: ${({ textAlign }) => textAlign};
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  min-width: ${({ minWidth }) => minWidth};
+  min-height: ${({ minHeight }) => minHeight};
+  display: ${({ display }) => display};
+  border: ${({ border }) => border};
+  border-radius: ${({ borderRadius }) => borderRadius};
+  overflow: ${({ overflow }) => overflow};
+  margin: ${({ margin }) => margin};
+  margin-top: ${({ marginTop }) => marginTop};
+  margin-left: ${({ marginLeft }) => marginLeft};
+  margin-right: ${({ marginRight }) => marginRight};
+  margin-bottom: ${({ marginBottom }) => marginBottom};
+  padding: ${({ padding }) => padding};
+  padding-top: ${({ paddingTop }) => paddingTop};
+  padding-left: ${({ paddingLeft }) => paddingLeft};
+  padding-right: ${({ paddingRight }) => paddingRight};
+  padding-bottom: ${({ paddingBottom }) => paddingBottom};
+  &:hover {
+    background-color: ${({ pseudoClass }) => pseudoClass?.hover?.backgroundColor};
+    opacity: 0.7;
+  }
+  &:disabled {
+    background-color: ${({ pseudoClass }) => pseudoClass?.disabled?.backgroundColor};
+    opacity: 0.5;
+  }
+`
+
+Button.defaultProps = {
+  padding: '1em',
+  border: 'none',
+  borderRadius: '20%',
+}
+
+export default Button

--- a/src/components/learnPage/atoms/text.tsx
+++ b/src/components/learnPage/atoms/text.tsx
@@ -1,6 +1,8 @@
-import styled from 'styled-components'
+import { theme } from '../../../themes'
+import styled, { css } from 'styled-components'
 
 interface TextProps {
+  variant?: 'small' | 'medium' | 'large'
   fontSize?: string
   fontColor?: string
   backgroundColor?: string
@@ -28,6 +30,28 @@ interface TextProps {
 }
 
 const Text = styled.span<TextProps>`
+  ${({ variant }) => {
+    switch (variant) {
+      case 'small':
+        return css`
+          font-size: ${theme.fontSizes[0]};
+          letter-spacing: ${theme.letterSpacings[0]};
+          line-height: ${theme.lineHeights[0]};
+        `
+      case 'medium':
+        return css`
+          font-size: ${theme.fontSizes[1]};
+          letter-spacing: ${theme.letterSpacings[1]};
+          line-height: ${theme.lineHeights[1]};
+        `
+      case 'large':
+        return css`
+          font-size: ${theme.fontSizes[2]};
+          letter-spacing: ${theme.letterSpacings[2]};
+          line-height: ${theme.lineHeights[2]};
+        `
+    }
+  }}
   font-size: ${({ fontSize }) => fontSize};
   color: ${({ fontColor }) => fontColor};
   background-color: ${({ backgroundColor }) => backgroundColor};
@@ -53,5 +77,9 @@ const Text = styled.span<TextProps>`
   padding-right: ${({ paddingRight }) => paddingRight};
   padding-bottom: ${({ paddingBottom }) => paddingBottom};
 `
+
+Text.defaultProps = {
+  variant: 'medium',
+}
 
 export default Text

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,12 @@
 import '@/styles/globals.css'
+import { theme } from '../themes'
 import type { AppProps } from 'next/app'
+import { ThemeProvider } from 'styled-components'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <ThemeProvider theme={theme}>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  )
 }

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -1,26 +1,20 @@
 import Text from '@/components/learnPage/atoms/text'
+import { theme } from '../themes'
 
 export default function Docs() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <Text>This is docPage.</Text>
-      <Text fontColor='red'>フォントカラー</Text>
-      <Text fontSize='2em'>フォントサイズ</Text>
-      <Text backgroundColor='blue'>背景色</Text>
-      <Text display='block' textAlign='center'>
-        配置
+      <Text variant='large' marginLeft='1em'>
+        イントロダクション
       </Text>
-      <Text border='2px white solid' width='10%'>
-        ボーダー
-      </Text>
-      <Text display='block' overflow='auto' fontSize='2em'>
-        はみ出し部分 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      </Text>
-      <Text backgroundColor='red' margin='30px'>
-        magin
-      </Text>
-      <Text backgroundColor='red' padding='10px'>
-        padding
+      <Text variant='small' marginLeft='1em'>
+        これは練習問題を通してPlantUMLの記述を学んでいくコンテンツです。
+        <br />
+        以下なんかイントロダクション的な説明文
+        <br />
+        学習に躓いた時や、よく使用する構文を知りたい場合はドキュメンテーションページをご確認下さい。
+        <br />
+        また、記述方法のより詳細な情報はPlantUMLを確認下さい。
       </Text>
     </div>
   )

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -1,27 +1,18 @@
+import Button from '@/components/learnPage/atoms/button'
 import Text from '@/components/learnPage/atoms/text'
 
 export default function Docs() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Text>This is docPage.</Text>
-      <Text fontColor='red'>フォントカラー</Text>
-      <Text fontSize='2em'>フォントサイズ</Text>
-      <Text backgroundColor='blue'>背景色</Text>
-      <Text display='block' textAlign='center'>
-        配置
-      </Text>
-      <Text border='2px white solid' width='10%'>
-        ボーダー
-      </Text>
-      <Text display='block' overflow='auto' fontSize='2em'>
-        はみ出し部分 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      </Text>
-      <Text backgroundColor='red' margin='30px'>
-        magin
-      </Text>
-      <Text backgroundColor='red' padding='10px'>
-        padding
-      </Text>
+      <div>
+        <Button backgroundColor='blue' pseudoClass={{ hover: { backgroundColor: 'yellow' } }}>
+          Button
+        </Button>
+        <Button disabled color='white' backgroundColor='blue'>
+          Disabled Button
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -1,0 +1,10 @@
+const colors = {
+  primary: '#0000FF',
+  secondary: '#00FFFF',
+  danger: '#FF0000',
+  gray: '#808080',
+  white: '#FFFFFF',
+  black: '#000000',
+}
+
+export default colors

--- a/src/themes/fontSize.ts
+++ b/src/themes/fontSize.ts
@@ -1,0 +1,3 @@
+const fontSizes: any = ['1em', '2em', '3em']
+
+export default fontSizes

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,11 @@
+import fontSizes from './fontSize'
+import colors from './colors'
+import letterSpacings from './letterSpacing'
+import lineHeights from './lineHeight'
+
+export const theme = {
+  fontSizes,
+  colors,
+  letterSpacings,
+  lineHeights,
+} as const

--- a/src/themes/letterSpacing.ts
+++ b/src/themes/letterSpacing.ts
@@ -1,0 +1,3 @@
+const letterSpacings: string[] = ['0.1px', '0.12px', '0.14px']
+
+export default letterSpacings

--- a/src/themes/lineHeight.ts
+++ b/src/themes/lineHeight.ts
@@ -1,0 +1,3 @@
+const lineHeights: string[] = ['1.5em', '2em', '3em']
+
+export default lineHeights


### PR DESCRIPTION
# 概要

- buttonAtomを作成しました。cssの当て方はtextと同様です。
- defaultでhover時にopacityを0.7にするようにしてあります。
- 基本的にはテキストのみのボタンに使用を想定しています。 

## 追加修正(3/25)
- primary, secondary, danger, grayの4種類のvariantを設定しました。
- 色はThemeのカラーパレットから参照しています。
- border-radiusは削除しました。