### PR TITLE
Feature/#4 add leran page routing

### DIFF
--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -5,20 +5,7 @@ import { theme } from '../themes'
 export default function Docs() {
   return (
     <Layout>
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <Text variant='large' marginLeft='1em'>
-          イントロダクション
-        </Text>
-        <Text variant='small' marginLeft='1em'>
-          これは練習問題を通してPlantUMLの記述を学んでいくコンテンツです。
-          <br />
-          以下なんかイントロダクション的な説明文
-          <br />
-          学習に躓いた時や、よく使用する構文を知りたい場合はドキュメンテーションページをご確認下さい。
-          <br />
-          また、記述方法のより詳細な情報はPlantUMLを確認下さい。
-        </Text>
-      </div>
+      <Text>docs Page</Text>
     </Layout>
   )
 }

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -1,9 +1,0 @@
-import Layout from '../components/common/templates/layout'
-
-export default function Learn() {
-  return (
-    <>
-      <Layout>This is learn page.</Layout>
-    </>
-  )
-}

--- a/src/pages/learn/[name].tsx
+++ b/src/pages/learn/[name].tsx
@@ -1,0 +1,55 @@
+import Layout from '@/components/common/templates/layout'
+import Text from '@/components/learnPage/atoms/text'
+
+const tempData = [
+  {
+    name: 'シーケンス図',
+  },
+  {
+    name: 'ユースケース図',
+  },
+  {
+    name: 'クラス図',
+  },
+  {
+    name: 'オブジェクト図',
+  },
+  {
+    name: 'アクティビティ図',
+  },
+  {
+    name: 'コンポーネント図',
+  },
+  {
+    name: '状態遷移図',
+  },
+  {
+    name: 'タイミング図',
+  },
+]
+
+export const getStaticPaths = async () => {
+  const data = tempData
+  const paths = data.map((v) => `/learn/${v.name}`)
+  return {
+    paths,
+    fallback: false,
+  }
+}
+
+export const getStaticProps = async (context: any) => {
+  const data = context.params
+  return {
+    props: {
+      data,
+    },
+  }
+}
+
+export default function LearnContent({ data }: any) {
+  return (
+    <Layout>
+      <Text variant='large'>{data.name}</Text>
+    </Layout>
+  )
+}

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+import styled from 'styled-components'
+import Layout from '../../components/common/templates/layout'
+import Text from '../../components/learnPage/atoms/text'
+import { theme } from '../../themes'
+
+const tempData = [
+  {
+    name: 'シーケンス図',
+  },
+  {
+    name: 'ユースケース図',
+  },
+  {
+    name: 'クラス図',
+  },
+  {
+    name: 'オブジェクト図',
+  },
+  {
+    name: 'アクティビティ図',
+  },
+  {
+    name: 'コンポーネント図',
+  },
+  {
+    name: '状態遷移図',
+  },
+  {
+    name: 'タイミング図',
+  },
+]
+
+const Anchor = styled(Text)`
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
+export default function Learn() {
+  return (
+    <Layout>
+      <div>
+        <Text variant='large' marginLeft='1em'>
+          イントロダクション
+        </Text>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {tempData.map((i) => (
+            <Anchor variant='small' key={i.name}>
+              <Link href={`/learn/${i.name}`}>{i.name}</Link>
+            </Anchor>
+          ))}
+        </div>
+      </div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
# 概要
LearnPage内から各diagramページのroutingを実装しました。

# 詳細
- "/learn"はイントロダクションを表示
- "/learn/[diagramName]”で対応するページを表示
- 仮のデータをfetchしているので、ドキュメントの保存が決まり次第、修正予定です。