### PR TITLE
Feature/fix auth problem and data mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ db/data
 
 # vscode
 .vscode
+
+# cert-key for nginx
+nginx/cert-key/

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -24,7 +24,7 @@ export class AuthController {
     const jwt = await this.authService.login(dto)
     res.cookie('access_token', jwt.accessToken, {
       httpOnly: true,
-      secure: false, // if https connection then true
+      secure: true, // if https connection then true
       sameSite: 'none',
       path: '/',
     })
@@ -38,7 +38,7 @@ export class AuthController {
   logout(@Req() req: Request, @Res({ passthrough: true }) res: Response): Msg {
     res.cookie('access_token', '', {
       httpOnly: true,
-      secure: false, // if https connection then true
+      secure: true, // if https connection then true
       sameSite: 'none',
       path: '/',
     })

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
       cookie: {
         httpOnly: true,
         sameSite: 'none',
-        secure: false, // if https connection then true
+        secure: true, // if https connection then true
       },
       value: (req: Request) => {
         return req.header('csrf-token')

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,10 +8,6 @@ import * as csurf from 'csurf'
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }))
-  app.enableCors({
-    credentials: true,
-    origin: ['http://localhost:3000', process.env.FRONTEND_URL],
-  })
   app.use(cookieParser())
   app.use(
     csurf({

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
   app:
     build:
       context: ./backend
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile.dev # change file if production env
     container_name: nest-server
     expose:
       - 3000
@@ -43,17 +43,19 @@ services:
   nginx:
     build:
       context: ./nginx
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev # change file if production env
     container_name: nginx
     depends_on:
       - app
     environment:
-      NGINX_SERVER_NAME: ${NGINX_SERVER_NAME}
+      NGINX_SERVER_NAME: localhost # change ${NGINX_SERVER_NAME} if production env
       NEST_HOST: nest-server
       NEST_PORT: 3000
       PLANTUML_HOST: plantuml-server
       PLANTUML_PORT: 8080
       NGINX_MAX_BODY: ${NGINX_MAX_BODY}
       NGINX_PORT: ${NGINX_PORT}
+      NGINX_SSL_PORT: ${NGINX_SSL_PORT}
     ports:
       - ${NGINX_PORT}:${NGINX_PORT}
+      - ${NGINX_SSL_PORT}:${NGINX_SSL_PORT}

--- a/frontend/hooks/useQueryUser.ts
+++ b/frontend/hooks/useQueryUser.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 export const useQueryUser = () => {
   const router = useRouter()
   const getUser = async () => {
-    const { data } = await axios.get(`http://localhost/user`)
+    const { data } = await axios.get(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/user`)
     return data
   }
   return useQuery({

--- a/frontend/hooks/useQueryUser.ts
+++ b/frontend/hooks/useQueryUser.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 export const useQueryUser = () => {
   const router = useRouter()
   const getUser = async () => {
-    const { data } = await axios.get(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/user`)
+    const { data } = await axios.get(`https://${process.env.AWS_IP_ADDRESS || 'localhost:443'}/api/user`)
     return data
   }
   return useQuery({

--- a/frontend/src/components/authPage/organisms/signInForm.tsx
+++ b/frontend/src/components/authPage/organisms/signInForm.tsx
@@ -21,7 +21,7 @@ const SignInForm = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
     try {
-      await axios.post(`http://localhost/auth/login`, {
+      await axios.post(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/login`, {
         email: email,
         password: password,
       })

--- a/frontend/src/components/authPage/organisms/signInForm.tsx
+++ b/frontend/src/components/authPage/organisms/signInForm.tsx
@@ -21,7 +21,7 @@ const SignInForm = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
     try {
-      await axios.post(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/login`, {
+      await axios.post(`https://${process.env.AWS_IP_ADDRESS || 'localhost:443'}/api/auth/login`, {
         email: email,
         password: password,
       })

--- a/frontend/src/components/authPage/organisms/signUpForm.tsx
+++ b/frontend/src/components/authPage/organisms/signUpForm.tsx
@@ -19,17 +19,14 @@ const SignUpForm = () => {
     event.preventDefault()
     try {
       await axios.post(
-        `http://localhost/auth/signup`,
+        `http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/signup`,
         {
           name: username,
           email: email,
           password: password,
         },
-        {
-          headers: { 'csrf-token': axios.defaults.headers.common['csrf-token'] },
-        },
       )
-      await axios.post(`http://localhost/auth/login`, {
+      await axios.post(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/login`, {
         email: email,
         password: password,
       })

--- a/frontend/src/components/authPage/organisms/signUpForm.tsx
+++ b/frontend/src/components/authPage/organisms/signUpForm.tsx
@@ -19,14 +19,14 @@ const SignUpForm = () => {
     event.preventDefault()
     try {
       await axios.post(
-        `http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/signup`,
+        `https://${process.env.AWS_IP_ADDRESS || 'localhost:443'}/api/auth/signup`,
         {
           name: username,
           email: email,
           password: password,
         },
       )
-      await axios.post(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/login`, {
+      await axios.post(`https://${process.env.AWS_IP_ADDRESS || 'localhost:443'}/api/auth/login`, {
         email: email,
         password: password,
       })

--- a/frontend/src/components/common/organisms/header.tsx
+++ b/frontend/src/components/common/organisms/header.tsx
@@ -39,7 +39,7 @@ const Header = () => {
   const handleLogout = async () => {
     setIsLoggedIn(false)
     queryClient.removeQueries(['user'])
-    await axios.post(`http://localhost/auth/logout`)
+    await axios.post(`https://${process.env.AWS_IP_ADDRESS || 'localhost:443'}/api/auth/logout`)
     router.push('/signIn')
   }
   return (

--- a/frontend/src/components/common/organisms/umlPic.tsx
+++ b/frontend/src/components/common/organisms/umlPic.tsx
@@ -14,7 +14,7 @@ const fetcher: Fetcher<string, string> = async (url) => {
 export default function UmlPic({ umlText }: Props) {
   const plantUmlEncoder = require('plantuml-encoder') // eslint-disable-line
   const encodedText = plantUmlEncoder.encode(umlText)
-  const url = process.env.AWS_IP_ADDRESS || 'localhost'
+  const url = process.env.AWS_IP_ADDRESS || 'localhost:80'
   const { data, error } = useSWR(`http://${url}/plantuml/png/${encodedText}`, fetcher)
 
   if (error) {

--- a/frontend/src/components/workPage/organisms/currentDiagrams.tsx
+++ b/frontend/src/components/workPage/organisms/currentDiagrams.tsx
@@ -2,20 +2,26 @@ import { Project, Diagram } from '@/interfaces/dataTypes'
 import styled from 'styled-components'
 import Icon from '../atoms/icon'
 import RectButton from '../atoms/rectButton'
+import { useEffect, useState } from 'react'
 
 type Props = {
   projects?: (Project & { diagrams: Diagram[] })[]
   handleSelectDiagram: (dId: number, pId?: number | undefined) => void
 }
 
-export default function currentDiagrams({ projects, handleSelectDiagram }: Props) {
-  let diagramArray: (Diagram & { projectId: number; projectName: string })[] = []
-  projects?.forEach((p) =>
-    p.diagrams.forEach((d) => diagramArray.push({ ...d, projectId: p.id, projectName: p.name })),
-  )
-  diagramArray = diagramArray
-    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
-    .slice(0, 3)
+export default function CurrentDiagrams({ projects, handleSelectDiagram }: Props) {
+  const [ diagramArray, setDiagramArray ] = useState<(Diagram & { projectId: number; projectName: string })[]>([])
+  useEffect(()=>{
+    let arr: (Diagram & { projectId: number; projectName: string })[] = []
+    projects?.forEach((p) => {
+      const dArr:(Diagram & { projectId: number; projectName: string })[] = p.diagrams.map(d => {
+        return { ...d, projectId: p.id, projectName: p.name }
+      })
+      arr = [...arr, ...dArr]
+      arr = arr.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, 3)
+    })
+    setDiagramArray(arr)
+  },[projects])
 
   return (
     <>

--- a/frontend/src/components/workPage/templates/diagramEditor.tsx
+++ b/frontend/src/components/workPage/templates/diagramEditor.tsx
@@ -7,7 +7,7 @@ import Icon from '../atoms/icon'
 
 type Props = {
   projectId: number
-  diagram: Diagram
+  diagram?: Diagram
   editDiagramName: (projectId: number, diagramId: number, name: string) => void
   editDiagramContent: (projectId: number, diagramId: number, content: string) => void
   deleteDiagram: (projectId: number, diagramId: number) => void
@@ -20,9 +20,11 @@ export default function DiagramEditor({
   editDiagramContent,
   deleteDiagram,
 }: Props) {
-  const [content, setContent] = useState(diagram.content ?? '')
+  const [content, setContent] = useState(diagram?.content ?? '')
   const [nameEdit, setNameEdit] = useState(false)
-  const [name, setName] = useState(diagram.name)
+  const [name, setName] = useState(diagram?.name ?? '')
+
+  if(!diagram) return <></>
 
   return (
     <Container>

--- a/frontend/src/components/workPage/templates/projectBoard.tsx
+++ b/frontend/src/components/workPage/templates/projectBoard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import DiagramsInProject from '../organisms/diagramsInProject'
 
 type Props = {
-  project: Project & { diagrams: Diagram[] }
+  project?: Project & { diagrams: Diagram[] }
   editProjectName: (id: number, name: string) => void
   handleSelectDiagram: (dId: number, pId?: number) => void
   addDiagram: (projectId: number) => void
@@ -19,7 +19,8 @@ export default function ProjectBoard({
 }: Props) {
   return (
     <Container>
-      <DiagramsInProject
+      {!project? <></> : <>
+        <DiagramsInProject
         projectName={project.name}
         projectId={project.id}
         diagrams={project.diagrams}
@@ -35,6 +36,7 @@ export default function ProjectBoard({
         }
       </div>
       <DeleteButton onClick={() => deleteProject(project.id)}>このプロジェクトを削除</DeleteButton>
+      </>}
     </Container>
   )
 }

--- a/frontend/src/components/workPage/templates/sidebar.tsx
+++ b/frontend/src/components/workPage/templates/sidebar.tsx
@@ -6,7 +6,7 @@ import SelectProjects from '../organisms/selectProjects'
 import SelectBoards from '../organisms/selectBoards'
 
 type Props = {
-  projects: (Project & { diagrams: Diagram[] })[]
+  projects?: (Project & { diagrams: Diagram[] })[]
   isMyBoard: boolean
   handleSelectBoard: (b: boolean) => void
   projectId: number | null

--- a/frontend/src/interfaces/dataTypes.d.ts
+++ b/frontend/src/interfaces/dataTypes.d.ts
@@ -1,6 +1,8 @@
 export interface User {
-  id: number
-  name: string
+  id: number;
+  createdAt: Date;
+  name: string;
+  email: string;
 }
 
 export interface Project {

--- a/frontend/src/interfaces/dataTypes.d.ts
+++ b/frontend/src/interfaces/dataTypes.d.ts
@@ -1,8 +1,8 @@
 export interface User {
-  id: number;
-  createdAt: Date;
-  name: string;
-  email: string;
+  id: number
+  createdAt: Date
+  name: string
+  email: string
 }
 
 export interface Project {

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -45,7 +45,7 @@ export default function App({ Component, pageProps }: AppProps) {
   axios.defaults.withCredentials = true
   useEffect(() => {
     const getCsrfToken = async () => {
-      const { data } = await axios.get(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/csrf`)
+      const { data } = await axios.get(`https://${process.env.AWS_IP_ADDRESS || 'localhost:443'}/api/auth/csrf`)
       axios.defaults.headers.common['csrf-token'] = data.csrfToken
     }
     getCsrfToken()

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -42,10 +42,10 @@ const queryClient = new QueryClient({
 })
 
 export default function App({ Component, pageProps }: AppProps) {
+  axios.defaults.withCredentials = true
   useEffect(() => {
-    axios.defaults.withCredentials = true
     const getCsrfToken = async () => {
-      const { data } = await axios.get(`http://localhost/auth/csrf`)
+      const { data } = await axios.get(`http://${process.env.AWS_IP_ADDRESS || 'localhost'}/api/auth/csrf`)
       axios.defaults.headers.common['csrf-token'] = data.csrfToken
     }
     getCsrfToken()

--- a/frontend/src/types/data.guard.ts
+++ b/frontend/src/types/data.guard.ts
@@ -38,7 +38,11 @@ export function isUser(user: unknown): user is User {
     user !== null &&
     'id' in user &&
     'name' in user &&
+    'createdAt' in user &&
+    'email' in user && 
     typeof user.id === 'number' &&
-    typeof user.name === 'string'
+    typeof user.name === 'string' &&
+    user.createdAt instanceof Date &&
+    typeof user.email === 'string'
   )
 }

--- a/frontend/src/types/data.guard.ts
+++ b/frontend/src/types/data.guard.ts
@@ -39,7 +39,7 @@ export function isUser(user: unknown): user is User {
     'id' in user &&
     'name' in user &&
     'createdAt' in user &&
-    'email' in user && 
+    'email' in user &&
     typeof user.id === 'number' &&
     typeof user.name === 'string' &&
     user.createdAt instanceof Date &&

--- a/nginx/Dockerfile.dev
+++ b/nginx/Dockerfile.dev
@@ -1,0 +1,13 @@
+FROM nginx:1.23.4-alpine
+
+COPY ./entrypoint-nginx.sh /
+
+RUN set -ex && \
+	apk add --no-cache bash && \
+	chmod +x /entrypoint-nginx.sh
+
+COPY ./vhost.template /etc/nginx/conf.d/vhost.template
+ADD ./cert-key/localhost.pem /etc/certs/localhost.pem
+ADD ./cert-key/localhost-key.pem /etc/certs/localhost-key.pem
+
+CMD ["/entrypoint-nginx.sh"]

--- a/nginx/vhost.template
+++ b/nginx/vhost.template
@@ -5,6 +5,31 @@ server {
 	client_max_body_size ${NGINX_MAX_BODY};
 
 	location /api/ {
+		return 301 https://$host$request_uri;
+	}
+
+	location /plantuml/ {
+
+		proxy_pass  http://${PLANTUML_HOST}:${PLANTUML_PORT}/plantuml/;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Host $server_name;
+		proxy_set_header X-Forwarded-Proto https;
+	}
+}
+
+server {
+	listen ${NGINX_SSL_PORT} ssl;
+	server_name ${NGINX_SERVER_NAME};
+	client_max_body_size ${NGINX_MAX_BODY};
+
+  	ssl_certificate /etc/certs/localhost.pem;
+  	ssl_certificate_key /etc/certs/localhost-key.pem;
+
+  	ssl_session_timeout 5m;
+
+	location /api/ {
 		set $cors "0";
 
 		if ($http_origin ~* (https?://(uml-generator-dev.*\.vercel\.app$|uml-diagram-generator\.vercel\.app$|localhost:3000))) {
@@ -33,42 +58,6 @@ server {
         add_header Access-Control-Allow-Credentials true always;
 
 		proxy_pass  http://${NEST_HOST}:${NEST_PORT}/api/;
-		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Host $server_name;
-		proxy_set_header X-Forwarded-Proto https;
-	}
-
-	location /plantuml/ {
-		set $cors "0";
-
-		if ($http_origin ~* (https?://(uml-generator-dev.*\.vercel\.app$|uml-diagram-generator\.vercel\.app$|localhost:3000))) {
-            set $cors "1";
-        }
-
-		if ($cors = "0") {
-			return 403;
-		}
-
-		if ($request_method = "OPTIONS") {
-			set $cors "2";
-		}
-
-		if ($cors = "2") {
-			add_header Access-Control-Allow-Origin $http_origin always;
-            add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type' always;
-            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS' always;
-            add_header Access-Control-Allow-Credentials true always;
-			return 200;
-		}
-
-        add_header Access-Control-Allow-Origin $http_origin always;
-        add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type' always;
-        add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS' always;
-        add_header Access-Control-Allow-Credentials true always;
-
-		proxy_pass  http://${PLANTUML_HOST}:${PLANTUML_PORT}/plantuml/;
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/vhost.template
+++ b/nginx/vhost.template
@@ -5,7 +5,33 @@ server {
 	client_max_body_size ${NGINX_MAX_BODY};
 
 	location /api/ {
-		# try_files $uri =404;
+		set $cors "0";
+
+		if ($http_origin ~* (https?://(uml-generator-dev.*\.vercel\.app$|uml-diagram-generator\.vercel\.app$|localhost:3000))) {
+            set $cors "1";
+        }
+
+		if ($cors = "0") {
+			return 403;
+		}
+
+		if ($request_method = "OPTIONS") {
+			set $cors "2";
+		}
+
+		if ($cors = "2") {
+			add_header Access-Control-Allow-Origin $http_origin always;
+			add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type, csrf-token' always;
+            add_header Access-Control-Allow-Methods 'GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS' always;
+            add_header Access-Control-Allow-Credentials true always;
+			return 200;
+		}
+
+		add_header Access-Control-Allow-Origin $http_origin always;
+		add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type, csrf-token' always;
+        add_header Access-Control-Allow-Methods 'GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS' always;
+        add_header Access-Control-Allow-Credentials true always;
+
 		proxy_pass  http://${NEST_HOST}:${NEST_PORT}/api/;
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
@@ -15,7 +41,33 @@ server {
 	}
 
 	location /plantuml/ {
-		# try_files $uri =404;
+		set $cors "0";
+
+		if ($http_origin ~* (https?://(uml-generator-dev.*\.vercel\.app$|uml-diagram-generator\.vercel\.app$|localhost:3000))) {
+            set $cors "1";
+        }
+
+		if ($cors = "0") {
+			return 403;
+		}
+
+		if ($request_method = "OPTIONS") {
+			set $cors "2";
+		}
+
+		if ($cors = "2") {
+			add_header Access-Control-Allow-Origin $http_origin always;
+            add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type' always;
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS' always;
+            add_header Access-Control-Allow-Credentials true always;
+			return 200;
+		}
+
+        add_header Access-Control-Allow-Origin $http_origin always;
+        add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type' always;
+        add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS' always;
+        add_header Access-Control-Allow-Credentials true always;
+
 		proxy_pass  http://${PLANTUML_HOST}:${PLANTUML_PORT}/plantuml/;
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 現状と概要
現在の認証機能はクライアントからのcsrf-tokenリクエストとaccess-tokenリクエストが不可能になっている。前者はブラウザがCORS対策として自動的に送るプリフライトリクエストにてサーバーへのアクセスが拒否され、後者はこれに加えてaccess-tokenのCookieでの保存がssl/tsl接続でないと拒否される（same-site: noneではsecure: trueのレスポンスしか許可できない）ためである。
このことを踏まえて、後回しにするとしていたCORS設定とSSL/TLS接続設定を行った。　　
また、認証機能の稼働確認後に発見された作業ページでのAPIとの非同期処理後のステートのミューテーションが期待の動きをしていないバグの修正を行った。

## CORS問題＆SSL/TLS接続問題の解決
client-nginx間のでプリフライトリクエストによるCORSの解決が行えるようにnginxの設定ファイルを修正した。　　
また、ssl接続が可能となるようにnginxのバージョンを最新のものとした。これにより内部的にOpenSSLがTLSv1.3（現在のブラウザのデフォルトSSL/TLSプロトコルバージョン）に対応してブラウザとのプロトコルエラーを解消した。　　
また、SSL/TLS接続では必ずSSL証明書が必要となる。これに関しては下記を参照。なお、ドメインが必要となるため無料のものを契約して取得した。AWS Route53での名前解決を設定したが、これにより従量課金のDNS名前解決とドメインへのクエリの数に応じた料金が発生するため、直ちに請求に関する設定権限を与えて頂きたい。

### SSL/TLS接続のローカル環境設定
開発時にはフロントエンド（localhost:3000）- バックエンド（localhost:443）間のSSL/TLS接続が必要となる。
ローカル環境では[mkcert](https://github.com/FiloSottile/mkcert)を利用してローカルホスト用のSSL証明書を発行することが簡単なので以下のセットアップを行なって欲しい。

```brew install mkcert```(Homebrewを使用している場合)
```mkcert -install``` (自己認証局用の証明書・秘密鍵の作成)
```cd {devRootDir}/nginx/cert-key``` (開発フォルダのnginxフォルダ内のkey保管フォルダに移動)
```mkcert localhost``` (localhostのサーバー証明書と秘密鍵を生成)
```mv ????-key.pem localhost-key.pem```(生成物の名前がlocalhostではない場合 ex) localhost+1-key.pem は名前変更)
```mv ????-pem localhost.pem```(生成物の名前がlocalhostではない場合 ex) localhost+1.pem は名前変更)
これにより生成された証明書と秘密鍵を用いてローカルのnginxサーバーがhttpsでのssl/tls接続を可能とします。

### プロダクションでのSSL/TLS接続について
現状はドメイン取得とAWS Route53でのDNS利用を設定しています。まだプロダクションのEC2インスタンスでのSSL証明書発行は行なっていません。
考えられる方法としてLetsencryptでの無料証明書を作成することです。
しかしながら、AWS Route53の利用だけでもDNSでの名前解決とドメインへのクエリ数に応じて料金が発生するため、請求の設定を早急に完了したいです。現状は私に権限がなく自身のクレジットを登録できないので早急に対応をお願いします。
上記対応完了後にSSL証明書発行と自動更新の設定をしたいです。

### 作業ページのデータミューテーション
next.js推奨のswrを使用してデータフェッチとミューテーションを実施していましたが、非同期処理発生後のステートデータのミューテーションによる更新が機能してなかったので、axiosのPromiseに連続してリクエストが成功した際に連続してミューテーションが非同期で実施されるように修正しました。
また、データの更新に伴う各コンポーネントがpropsとして所有していたstateの変更に伴うエラーの解決を行いました。

